### PR TITLE
Fix/gazebo description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+### Fixed
+- Corrected warnings and multirobot on `rb_theron_description`. See package notes changelog for more information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Corrected warnings and multirobot on `rb_theron_description`. See package notes changelog for more information
+- Corrected warnings and multirobot on `rb_theron_description`. See package notes changelog for more informat

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# RB-THERON COMMON
+
+RB-THERON common packages

--- a/rb_theron_description/CHANGELOG.md
+++ b/rb_theron_description/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+-

--- a/rb_theron_description/CHANGELOG.md
+++ b/rb_theron_description/CHANGELOG.md
@@ -8,4 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--
+### fixed
+- Corrected `common.gazebo.xacro` for allowing namespaces different than `robot`
+- Corrected warnings (melodic) or errors (o) about `xacro:cylinder_inertia` and `xacro:insert_block`
+- Removed wheels on `rb_thero.urdf.xacro` (already on `rb_theron_base.urdf.xacro`)
+- Corrected wheels inertial

--- a/rb_theron_description/robots/rb_theron.urdf.xacro
+++ b/rb_theron_description/robots/rb_theron.urdf.xacro
@@ -12,12 +12,6 @@
 	<!-- Import differential base elements -->
 	<xacro:include filename="$(find rb_theron_description)/robots/rb_theron_base.urdf.xacro" />
 
-	<!-- Import wheels -->
-	<xacro:include filename="$(find rb_theron_description)/urdf/wheels/rubber_wheel_150.urdf.xacro" />
-
-	<!-- Import casters -->
-	<xacro:include filename="$(find rb_theron_description)/urdf/wheels/castor.urdf.xacro" />
-
 	<!-- Import all available sensors -->
 	<xacro:include filename="$(find robotnik_sensors)/urdf/all_sensors.urdf.xacro" />
 

--- a/rb_theron_description/robots/rb_theron_base.urdf.xacro
+++ b/rb_theron_description/robots/rb_theron_base.urdf.xacro
@@ -47,7 +47,7 @@
   	<xacro:rubber_wheel prefix="${prefix}left" parent="${prefix}base_link" hq="${hq}">
   		<origin xyz="${wheel_offset_x} ${wheel_offset_y} ${wheel_offset_z}" rpy="0 0 0"/>
   	</xacro:rubber_wheel>
-	
+
   	<xacro:caster prefix="${prefix}front_left" parent="${prefix}base_link" hq="${hq}">
   		<origin xyz="0.235 0.1825 0.046" rpy="0 0 0"/>
   	</xacro:caster>

--- a/rb_theron_description/urdf/common.gazebo.xacro
+++ b/rb_theron_description/urdf/common.gazebo.xacro
@@ -6,7 +6,7 @@
 		<gazebo>
 			<plugin name="ros_control" filename="libgazebo_ros_control.so">
 				<!--robotNamespace>/robot</robotNamespace-->
-				<robotParam>robot/robot_description</robotParam>
+				<robotParam>robot_description</robotParam>
 				<controlPeriod>0.001</controlPeriod>
 				<robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
 				<legacyModeNS>true</legacyModeNS>

--- a/rb_theron_description/urdf/wheels/castor.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/castor.urdf.xacro
@@ -29,7 +29,7 @@
   <joint name="${prefix}joint_support" type="continuous">
       <parent link="${parent}"/>
       <child link="${prefix}support"/>
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <axis xyz="0 0 1" rpy="0 ${M_PI} 0" />
       <limit effort="100" velocity="100"/>
       <!-- joint_properties damping="1.5" friction="1.5"/ -->
@@ -68,7 +68,7 @@
      <joint name="${prefix}joint_wheel" type="continuous">
        <parent link="${parent}"/>
        <child link="${prefix}wheel"/>
-       <insert_block name="origin" />
+       <xacro:insert_block name="origin" />
        <axis xyz="0 1 0" rpy="0 0 0" />
        <limit effort="100" velocity="100"/>
        <joint_properties damping="0.1" friction="0.1"/>

--- a/rb_theron_description/urdf/wheels/castor.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/castor.urdf.xacro
@@ -19,8 +19,8 @@
 
   <xacro:macro name="cylinder_inertia" params="m r h">
     <inertia  ixx="${m*(3*r*r+h*h)/12}" ixy = "0" ixz = "0"
-              iyy="${m*(3*r*r+h*h)/12}" iyz = "0"
-              izz="${m*r*r/2}" />
+              izz="${m*(3*r*r+h*h)/12}" iyz = "0"
+              iyy="${m*r*r/2}" />
   </xacro:macro>
 
   <xacro:macro name="caster" params="prefix parent *origin hq">

--- a/rb_theron_description/urdf/wheels/rubber_wheel_125.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/rubber_wheel_125.urdf.xacro
@@ -49,7 +49,7 @@
 			<inertial>
 				<mass value="${wheel_mass}" />
 				<origin xyz="0 0 0" />
-				<cylinder_inertia m="${wheel_mass}" r="${wheel_radius}" h="${wheel_height}" />
+				<xacro:cylinder_inertia m="${wheel_mass}" r="${wheel_radius}" h="${wheel_height}" />
 			</inertial>
 		</link>
 

--- a/rb_theron_description/urdf/wheels/rubber_wheel_125.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/rubber_wheel_125.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="wheel" 
+<robot name="wheel"
 	xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 	<xacro:include filename="$(find rb_theron_description)/urdf/wheels/rubber_wheel.transmission.xacro"/>

--- a/rb_theron_description/urdf/wheels/rubber_wheel_125.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/rubber_wheel_125.urdf.xacro
@@ -15,7 +15,14 @@
 
 
 	<xacro:macro name="cylinder_inertia" params="m r h">
-		<inertia ixx="${m*(3*r*r+h*h)/12}" ixy = "0" ixz = "0" iyy="${m*(3*r*r+h*h)/12}" iyz = "0" izz="${m*r*r/2}" />
+		<inertia
+			iyy="${m*r*r/2}"
+			ixx="${m*(3*r*r+h*h)/12}"
+			izz="${m*(3*r*r+h*h)/12}"
+			ixy="0"
+			ixz="0"
+			iyz="0"
+		/>
 	</xacro:macro>
 
 	<xacro:macro name="rubber_wheel" params="prefix parent *origin reflect hq">

--- a/rb_theron_description/urdf/wheels/rubber_wheel_150.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/rubber_wheel_150.urdf.xacro
@@ -49,7 +49,7 @@
 			<inertial>
 				<mass value="${wheel_mass}" />
 				<origin xyz="0 0 0" />
-				<cylinder_inertia m="${wheel_mass}" r="${wheel_radius}" h="${wheel_height}" />
+				<xacro:cylinder_inertia m="${wheel_mass}" r="${wheel_radius}" h="${wheel_height}" />
 			</inertial>
 		</link>
 

--- a/rb_theron_description/urdf/wheels/rubber_wheel_150.urdf.xacro
+++ b/rb_theron_description/urdf/wheels/rubber_wheel_150.urdf.xacro
@@ -15,7 +15,14 @@
 
 
 	<xacro:macro name="cylinder_inertia" params="m r h">
-		<inertia ixx="${m*(3*r*r+h*h)/12}" ixy = "0" ixz = "0" iyy="${m*(3*r*r+h*h)/12}" iyz = "0" izz="${m*r*r/2}" />
+		<inertia
+			iyy="${m*r*r/2}"
+			ixx="${m*(3*r*r+h*h)/12}"
+			izz="${m*(3*r*r+h*h)/12}"
+			ixy="0"
+			ixz="0"
+			iyz="0"
+		/>
 	</xacro:macro>
 
 	<xacro:macro name="rubber_wheel" params="prefix parent *origin hq">


### PR DESCRIPTION
# fixed
- Corrected `common.gazebo.xacro` for allowing namespaces different than `robot`
- Corrected warnings (melodic) or errors (o) about `xacro:cylinder_inertia` and `xacro:insert_block`
- Removed wheels on `rb_thero.urdf.xacro` (already on `rb_theron_base.urdf.xacro`)
- Corrected wheels inertial